### PR TITLE
Add 'craft_guide' as optional dependency

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
 default
+craft_guide?


### PR DESCRIPTION
For compatibility with [cornernote's *craft_guide* mod](http://cornernote.github.io/minetest-craft_guide/).