### PR TITLE
My adjustments for whynot game

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,8 @@
 -- Functions
 --
 
+local trash_can_throw_in = minetest.settings:get_bool("trash_can_throw_in") or false
+
 local fdir_to_front = {
 	{x=0, z=1},
 	{x=1, z=0},
@@ -230,28 +232,30 @@ minetest.register_craft({
 -- Misc
 --
 
--- Remove any items thrown in trash can.
-local old_on_step = minetest.registered_entities["__builtin:item"].on_step
-minetest.registered_entities["__builtin:item"].on_step = function(self, dtime)
-	local item_pos = self.object:getpos()
-	-- Round the values.  Not essential, but makes logging look nicer.
-	for key, value in pairs(item_pos) do item_pos[key] = math.floor(value + 0.5) end
-	if minetest.get_node(item_pos).name == "trash_can:trash_can_wooden" then
-		local item_stack = ItemStack(self.itemstring)
-		local inv = minetest.get_inventory({type="node", pos=item_pos})
-		local leftover = inv:add_item("trashlist", item_stack)
-		if leftover:get_count() == 0 then
-			self.object:remove()
-			minetest.log("action", item_stack:to_string() ..
-				" added to trash can at " .. minetest.pos_to_string(item_pos))
-		elseif item_stack:get_count() - leftover:get_count() ~= 0 then
-			self.set_item(self, leftover:to_string())
-			minetest.log("action", item_stack:to_string() ..
-				" added to trash can at " .. minetest.pos_to_string(item_pos) ..
-				" with " .. leftover:to_string() .. " left over"
-			)
+if trash_can_throw_in then
+	-- Remove any items thrown in trash can.
+	local old_on_step = minetest.registered_entities["__builtin:item"].on_step
+	minetest.registered_entities["__builtin:item"].on_step = function(self, dtime)
+		local item_pos = self.object:getpos()
+		-- Round the values.  Not essential, but makes logging look nicer.
+		for key, value in pairs(item_pos) do item_pos[key] = math.floor(value + 0.5) end
+		if minetest.get_node(item_pos).name == "trash_can:trash_can_wooden" then
+			local item_stack = ItemStack(self.itemstring)
+			local inv = minetest.get_inventory({type="node", pos=item_pos})
+			local leftover = inv:add_item("trashlist", item_stack)
+			if leftover:get_count() == 0 then
+				self.object:remove()
+				minetest.log("action", item_stack:to_string() ..
+					" added to trash can at " .. minetest.pos_to_string(item_pos))
+			elseif item_stack:get_count() - leftover:get_count() ~= 0 then
+				self.set_item(self, leftover:to_string())
+				minetest.log("action", item_stack:to_string() ..
+					" added to trash can at " .. minetest.pos_to_string(item_pos) ..
+					" with " .. leftover:to_string() .. " left over"
+				)
+			end
+			return
 		end
-		return
+		old_on_step(self, dtime)
 	end
-	old_on_step(self, dtime)
 end

--- a/init.lua
+++ b/init.lua
@@ -25,14 +25,14 @@ end
 --
 -- Custom Sounds
 --
-function default.node_sound_metal_defaults(table)
-	table = table or {}
-	table.footstep = table.footstep or {name="default_hard_footstep", gain=0.4}
-	table.dig = table.dig or {name="metal_bang", gain=0.6}
-	table.dug = table.dug or {name="default_dug_node", gain=1.0}
-
-	default.node_sound_defaults(table)
-	return table
+local function get_dumpster_sound()
+	local sndtab = {
+		footstep = {name="default_hard_footstep", gain=0.4},
+		dig = {name="metal_bang", gain=0.6},
+		dug = {name="default_dug_node", gain=1.0}
+	}
+	default.node_sound_defaults(sndtab)
+	return sndtab
 end
 
 --
@@ -155,7 +155,7 @@ minetest.register_node("trash_can:dumpster", {
 		oddly_breakable_by_hand = 1,
 	},
 
-	sounds = default.node_sound_metal_defaults(),
+	sounds = get_dumpster_sound(),
 
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+# Requires some additional processing to check all items in the world each server step
+trash_can_throw_in (Allow throwing trash into the trash can) bool true


### PR DESCRIPTION
I did 2x changes to add the mod to the whynot game as requested in https://github.com/bell07/minetest-game-whynot/issues/10

1 commit: the default.node_sound_metal_defaults() should not be overriden globally
2 commit: Be able to disable the hacky throw-in function (overrides __builtin:item)

I was not able to hit the trash can with the function, and do not like the idea all items are checked for trash. There is a to-do to port the function to node-timers and minetest.get_objects_inside_radius() but it is not my task.