### PR TITLE
Don't crash if default mod is not installed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -20,7 +20,7 @@ else -- fallback, assume default (Minetest Game) is loaded
 	moditems.iron_item = "default:steel_ingot" -- MTG iron ingot
 	moditems.coal_item = "default:coalblock"   -- MTG coal block
 	moditems.green_dye = "dye:dark_green"      -- MTG version of green dye
-	moditems.sounds = default.node_sound_defaults
+	moditems.sounds = default and default.node_sound_defaults
 	moditems.trashcan_infotext = S("Trash Can")
 	moditems.dumpster_infotext = S("Dumpster")
 	moditems.boxart = ""


### PR DESCRIPTION
```
ModError: ModError: Failed to load and run script from .../mods/trash_can/init.lua:
.../mods/trash_can/init.lua:23: attempt to index global 'default' (a nil value) stack traceback:
.../mods/trash_can/init.lua:23: in main chunk Check debug.txt for details.
```