### PR TITLE
Fix and improve throwing trash into the can

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -263,10 +263,11 @@ minetest.register_craft({
 if trash_can_throw_in then
 	-- Remove any items thrown in trash can.
 	local old_on_step = minetest.registered_entities["__builtin:item"].on_step
-	minetest.registered_entities["__builtin:item"].on_step = function(self, dtime)
-		local item_pos = self.object:getpos()
+	minetest.registered_entities["__builtin:item"].on_step = function(self, dtime, ...)
+		local item_pos = self.object:get_pos()
+		item_pos.y = item_pos.y - 0.325
+		item_pos = vector.round(item_pos)
 		-- Round the values.  Not essential, but makes logging look nicer.
-		for key, value in pairs(item_pos) do item_pos[key] = math.floor(value + 0.5) end
 		if minetest.get_node(item_pos).name == "trash_can:trash_can_wooden" then
 			local item_stack = ItemStack(self.itemstring)
 			local inv = minetest.get_inventory({type="node", pos=item_pos})
@@ -284,6 +285,6 @@ if trash_can_throw_in then
 			end
 			return
 		end
-		old_on_step(self, dtime)
+		old_on_step(self, dtime, ...)
 	end
 end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,2 @@
 # Requires some additional processing to check all items in the world each server step
-trash_can_throw_in (Allow throwing trash into the trash can) bool true
+trash_can_throw_in (Allow throwing trash into the trash can) bool false


### PR DESCRIPTION
* The settingtypes default value was mismatched with the actual code. settingtypes have been changed to agree with the code because this keeps the old behaviour.
* builtin item's on_step has more arguments than self and dtime now, so the varargs syntax is used to pass additional arguments on now Without this, the mod will crash when trash_can_throw_in is on.
* I have tweaked the calculation for where the trash can will pick objects up, since it was too easy to land items on the rim instead of them going in.
* The calculation for where the trash can will pick objects up has been tweaked upwards, since it was too easy to land items on the rim instead of them going in.
* vector.round is now used to ensure the logging co-ordinates are accurate instead of floor, since this is the same basic algorithm minetest\.get_node uses.