### PR TITLE
Optimize item checking code for throwing into trash can

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -263,7 +263,7 @@ minetest.register_craft({
 
 if minetest.settings:get_bool("trash_can_throw_in", false) then
 	minetest.register_abm({
-		label = "Throw items into wooden trasn cans",
+		label = "Throw items into wooden trash cans",
 		nodenames = { "trash_can:trash_can_wooden" },
 		interval = 0.5,
 		chance = 1,


### PR DESCRIPTION
This PR optimizes the codes handling throwing items into wooden trash cans.

* Before: *ALL* `__builtin:item` entities will be checked on *EACH* global step, regardless of whether they are inside a trash can
* After: All loaded wooden trash cans will be checked for entities inside them on every 0.5 seconds (i.e. 5 global steps), and process `__builtin:item` if any.

Under normal circumstances, the number of entities inside trash cans (even after counting non-items) would be less than the number of dropped items coexisting in the world (unless a group of fools decided to stand inside trash cans forever). Therefore, this mod optimizes the runtime load.

This PR is optimized in commit 3322a30 using node timers (set up when placing a trash can or loading an old one for the first time) instead of ABM (scanning all nodes every run).

This PR is tested and ready for review. Here is the footage of the testing:

https://github.com/minetest-mods/trash_can/assets/55009343/1897f274-daa5-43fb-b755-81cb840b1051

